### PR TITLE
support installer options per dependency

### DIFF
--- a/lib/pompompom.rb
+++ b/lib/pompompom.rb
@@ -52,7 +52,7 @@ module PomPomPom
           coordinate
         when Array
           MavenCoordinate.new(*coordinate)
-        when /^[^:]+:[^:]+:[^:]+$/ # TODO: also /^[^#]+#[^;];.+$/
+        when /^[^:]+:[^:]+:[^:]+(:[^:]+)*$/ # TODO: also /^[^#]+#[^;];.+$/
           MavenCoordinate.parse(coordinate)
         else
           raise ArgumentError, %("#{coordinate}" could not be converted to a Maven coordinate)

--- a/lib/pompompom/installer.rb
+++ b/lib/pompompom/installer.rb
@@ -15,7 +15,7 @@ module PomPomPom
         coordinate.to_ivy_module_id, 
         ivy.settings.default_resolver.name, 
         INSTALL_RESOLVER_NAME, 
-        install_options
+        install_options(coordinate.attributes)
       )
     end
 
@@ -45,13 +45,13 @@ module PomPomPom
       install_resolver
     end
 
-    def install_options
-      @install_options ||= begin
-        install_options = Ivy::InstallOptions.new
-        install_options.set_overwrite(true)
-        install_options.set_artifact_filter(Ivy::FilterHelper.get_artifact_type_filter('jar,bundle'))
-        install_options
-      end
+    def install_options(attributes)
+      defaulted = {"overwrite" => true, "transitive" => true}.merge(attributes)
+      install_options = Ivy::InstallOptions.new
+      install_options.set_overwrite(defaulted["overwrite"])
+      install_options.set_transitive(defaulted["transitive"])
+      install_options.set_artifact_filter(Ivy::FilterHelper.get_artifact_type_filter('jar,bundle'))
+      install_options
     end
 
     def install_pattern

--- a/lib/pompompom/maven_coordinate.rb
+++ b/lib/pompompom/maven_coordinate.rb
@@ -9,7 +9,22 @@ module PomPomPom
     attr_reader :group_id, :artifact_id, :version
 
     def initialize(*args)
-      @group_id, @artifact_id, @version = args
+      @group_id, @artifact_id, @version = args[0, 3]
+      @attributes = args[3..-1] || []
+    end
+
+    def attributes
+      hash = Hash[*@attributes.map{|attr| attr.split("=")}.flatten]
+      hash.merge(hash) do |k, v|
+        case v
+        when "false"
+          false
+        when "true"
+          true
+        else
+          v
+        end
+      end
     end
 
     begin :conversions


### PR DESCRIPTION
Hey, I hacked this quickly to allow specifying installer options such as `set_transitive()` in the dependency declaration, for example:

``` ruby
  configuration = {
    :repositories => {:clojars => 'http://clojars.org/repo/'},
    :dependencies => [
      "storm:storm:#{INSTALL_STORM_VERSION}",
      "org.jruby:jruby-complete:#{INSTALL_JRUBY_VERSION}:transitive=false"
    ],
    :destination => TARGET_DEPENDENCY_DIR
  }
```

This is mainly a FYI, as you might want to do this some other way.

Colin
